### PR TITLE
Bump color-eyre version to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jane-eyre"
-version = "0.3.0"
+version = "0.6.0"
 authors = ["Jane Lusby <jlusby@yaah.dev>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -13,4 +13,4 @@ categories = ["rust-patterns"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-color-eyre = "0.5"
+color-eyre = "0.6"


### PR DESCRIPTION
Bump color-eyre up to 0.6, which is the latest at the time of writing. Change the crate version to track the color-eyre version as well (might be a bad idea).